### PR TITLE
Add docs and config folder to paths-ignore

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,14 @@
 name: Java CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'config/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'config/**'
 
 jobs:
   build:


### PR DESCRIPTION
- If a change is made in either of these folders and pushed, a CI workflow is triggered, which is extremely time-consuming and unneccessary.