### PR TITLE
CI: rename misleading 'Merge to master' step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: master
 
-      - name: Merge to master
+      - name: Checkout triggering commit
         run: git checkout --progress --force ${{ github.sha }}
 
       - name: Run repository-wide tests


### PR DESCRIPTION
- The name `Merge to master` is extremely misleading for what it is actually doing, which is checking out the triggering commit.