### PR TITLE
Update check-trailing-whitespace warning severity

### DIFF
--- a/.github/check-trailing-whitespace.sh
+++ b/.github/check-trailing-whitespace.sh
@@ -14,6 +14,7 @@ awk '
         # (e.g. GitHub web editor)
         if ($1 ~ /\.md$/) {
             severity = "WARN"
+            ret = 1
         } else {
             severity = "ERROR"
             ret = 1

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -8,7 +8,7 @@
 
 PawFection is a **desktop app for managing animals in a pet shelter, optimized for use via a Command Line Interface** (CLI) while still
 having the benefits of a Graphical User Interface (GUI). It aims to provide a platform for volunteers to store and retrieve information
-about animals in a shelter easily. 
+about animals in a shelter easily.
 
 <!-- * Table of Contents -->
 - [Quick start](#quick-start)
@@ -133,7 +133,7 @@ Finds animals whose names/ID contain any of the given keywords.
 
 Format: `findn KEYWORD [MORE_KEYWORDS]…​` OR `findi KEYWORD [MORE_KEYWORDS]…​`
 
-* findn searches for animals whose names contain any of the given keywords while findi searches for animals whose ID 
+* findn searches for animals whose names contain any of the given keywords while findi searches for animals whose ID
 contain any of the given keywords.
 * The search is case-insensitive. e.g `pookie` will match `Pookie`
 * Animals matching at least one keyword will be returned (i.e. `OR` search).


### PR DESCRIPTION
- check-trailing-whitespace exits with status 1 on a WARN severity instead of status 0. This is to enforce stricter style checks

- Fix shell-scripts check violations