### PR TITLE
Add search command feature

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -46,9 +46,9 @@ public class StringUtil {
         }
 
         // iterate through the sentence
-        for(int i = 0; i < wordsInPreppedSentence.length; i++) {
+        for (int i = 0; i < wordsInPreppedSentence.length; i++) {
             if (wordsInPreppedSentence[i].equalsIgnoreCase(wordsInPreppedPhrase[0])) {
-                for(int j = 1; j < wordsInPreppedPhrase.length; j++) {
+                for (int j = 1; j < wordsInPreppedPhrase.length; j++) {
 
                     // if the sentence ends before the word does, return false
                     if (i + j >= wordsInPreppedSentence.length) {
@@ -61,8 +61,8 @@ public class StringUtil {
                     }
 
                     // if the last word matches, return true
-                    if (j == wordsInPreppedPhrase.length - 1 &&
-                            wordsInPreppedSentence[i + j].equalsIgnoreCase(wordsInPreppedPhrase[j])) {
+                    if (j == wordsInPreppedPhrase.length - 1
+                            && wordsInPreppedSentence[i + j].equalsIgnoreCase(wordsInPreppedPhrase[j])) {
                         return true;
                     }
                 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -21,21 +21,54 @@ public class StringUtil {
      *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
      *       </pre>
      * @param sentence cannot be null
-     * @param word cannot be null, cannot be empty, must be a single word
+     * @param phrase cannot be null, cannot be empty, must be a single word
      */
-    public static boolean containsWordIgnoreCase(String sentence, String word) {
+    public static boolean containsWordIgnoreCase(String sentence, String phrase) {
         requireNonNull(sentence);
-        requireNonNull(word);
+        requireNonNull(phrase);
 
-        String preppedWord = word.trim();
-        checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
-        checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
+        String preppedPhrase = phrase.trim();
+        checkArgument(!preppedPhrase.isEmpty(), "Phrase parameter cannot be empty");
+        String[] wordsInPreppedPhrase = preppedPhrase.split("\\s+");
 
         String preppedSentence = sentence;
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
-        return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+        // if the word is longer than the sentence, return false
+        if (wordsInPreppedPhrase.length > wordsInPreppedSentence.length) {
+            return false;
+        }
+
+        // if the phrase is one word long, check if the word is in the sentence
+        if (wordsInPreppedPhrase.length == 1) {
+            return Arrays.stream(wordsInPreppedSentence)
+                    .anyMatch(preppedPhrase::equalsIgnoreCase);
+        }
+
+        // iterate through the sentence
+        for(int i = 0; i < wordsInPreppedSentence.length; i++) {
+            if (wordsInPreppedSentence[i].equalsIgnoreCase(wordsInPreppedPhrase[0])) {
+                for(int j = 1; j < wordsInPreppedPhrase.length; j++) {
+
+                    // if the sentence ends before the word does, return false
+                    if (i + j >= wordsInPreppedSentence.length) {
+                        break;
+                    }
+
+                    // check if the subsequent words match
+                    if (!wordsInPreppedSentence[i + j].equalsIgnoreCase(wordsInPreppedPhrase[j])) {
+                        break;
+                    }
+
+                    // if the last word matches, return true
+                    if (j == wordsInPreppedPhrase.length - 1 &&
+                            wordsInPreppedSentence[i + j].equalsIgnoreCase(wordsInPreppedPhrase[j])) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/AnimalMessages.java
+++ b/src/main/java/seedu/address/logic/AnimalMessages.java
@@ -20,6 +20,10 @@ public class AnimalMessages {
             "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_PREAMBLE = "Command should not have preamble!";
 
+    public static final String MESSAGE_INVALID_SEARCH_KEYWORDS = "Search keywords cannot be empty! At least one "
+            + "prefix must be provided.";
+
+
     // ------------------------------------- Format Strings -----------------------------------------------
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW_FORMAT = "%d animals listed!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%s";

--- a/src/main/java/seedu/address/logic/commands/SearchAnimalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchAnimalCommand.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliAnimalSyntax.BREED;
+import static seedu.address.logic.parser.CliAnimalSyntax.DATE_OF_ADMISSION;
+import static seedu.address.logic.parser.CliAnimalSyntax.DATE_OF_BIRTH;
+import static seedu.address.logic.parser.CliAnimalSyntax.NAME;
+import static seedu.address.logic.parser.CliAnimalSyntax.PET_ID;
+import static seedu.address.logic.parser.CliAnimalSyntax.SEX;
+import static seedu.address.logic.parser.CliAnimalSyntax.SPECIES;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AnimalModel;
+import seedu.address.model.animal.KeywordPredicate;
+
+/**
+ * Searches for animals in the catalog based on keyword given (case-insensitive).
+ */
+public class SearchAnimalCommand extends AnimalCommand {
+    public static final String COMMAND_WORD = "search";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Searches for animals in the catalog based on keyword given (case insensitive). "
+            + "Parameters: KEYWORD\n"
+            + "Example: " + COMMAND_WORD + " Pookie";
+
+    public static final String EXAMPLE_USAGE = "Example: " + COMMAND_WORD + " "
+            + NAME.getPrefix() + "Pookie "
+            + PET_ID.getPrefix() + "1234 "
+            + SEX.getPrefix() + "MALE "
+            + DATE_OF_BIRTH.getPrefix() + "2019-01-01 "
+            + DATE_OF_ADMISSION.getPrefix() + "2019-01-01 "
+            + SPECIES.getPrefix() + "Dog "
+            + BREED.getPrefix() + "Poodle";
+
+    public static final String MESSAGE_SUCCESS = "%1$s result(s) found.";
+    private final KeywordPredicate predicate;
+
+    /**
+     * Creates a SearchAnimalCommand to search for animals in the catalog based on keyword given (case-insensitive).
+     */
+    public SearchAnimalCommand(KeywordPredicate predicate) {
+        requireAllNonNull(predicate);
+
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(AnimalModel model) throws CommandException {
+        model.updateFilteredAnimalList(predicate);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredAnimalList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SearchAnimalCommand // instanceof handles nulls
+                && predicate.equals(((SearchAnimalCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AnimalCatalogParser.java
+++ b/src/main/java/seedu/address/logic/parser/AnimalCatalogParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddAnimalCommand;
 import seedu.address.logic.commands.AnimalCommand;
 import seedu.address.logic.commands.DeleteAnimalCommand;
 import seedu.address.logic.commands.ListAnimalCommand;
+import seedu.address.logic.commands.SearchAnimalCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -56,6 +57,9 @@ public class AnimalCatalogParser {
 
         case DeleteAnimalCommand.COMMAND_WORD:
             return new DeleteAnimalCommandParser().parse(arguments);
+
+        case SearchAnimalCommand.COMMAND_WORD:
+            return new SearchAnimalCommandParser().parse(arguments);
         //
         //        case ClearAnimalCommand.COMMAND_WORD:
         //            return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -96,6 +96,13 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Returns true if at least one of the prefixes contains non-empty {@code Optional} values in the given.
+     */
+    public static boolean areSomePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
      * Returns the list of missing Prefixes in the {@code ArgumentMultimap}, based on the provided prefixes.
      *
      * @param argumentMultimap the ArgumentMultimap to check for missing prefixes.

--- a/src/main/java/seedu/address/logic/parser/SearchAnimalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchAnimalCommandParser.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliAnimalSyntax.SPECIES;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.AnimalMessages;
 import seedu.address.logic.commands.SearchAnimalCommand;
@@ -54,12 +53,6 @@ public class SearchAnimalCommandParser implements AnimalParser<SearchAnimalComma
 
         List<String> keywords = Arrays.asList(name, id, dob, doa, species, sex, breed);
 
-        //Remove empty fields
-        keywords = keywords.stream()
-                .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
-
-        //keywords should not be empty
-        assert(!keywords.isEmpty());
 
         return new SearchAnimalCommand(new KeywordPredicate(keywords));
     }

--- a/src/main/java/seedu/address/logic/parser/SearchAnimalCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchAnimalCommandParser.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliAnimalSyntax.BREED;
+import static seedu.address.logic.parser.CliAnimalSyntax.DATE_OF_ADMISSION;
+import static seedu.address.logic.parser.CliAnimalSyntax.DATE_OF_BIRTH;
+import static seedu.address.logic.parser.CliAnimalSyntax.NAME;
+import static seedu.address.logic.parser.CliAnimalSyntax.PET_ID;
+import static seedu.address.logic.parser.CliAnimalSyntax.SEX;
+import static seedu.address.logic.parser.CliAnimalSyntax.SPECIES;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.AnimalMessages;
+import seedu.address.logic.commands.SearchAnimalCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.animal.KeywordPredicate;
+
+/**
+ * Parses input arguments and creates a new SearchAnimalCommand object
+ */
+public class SearchAnimalCommandParser implements AnimalParser<SearchAnimalCommand> {
+
+    private static final Prefix[] MANDATORY_PREFIXES = CliAnimalSyntax.getMandatoryPrefixes().toArray(Prefix[]::new);
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SearchAnimalCommand
+     * and returns an SearchAnimalCommand object for execution.
+     *
+     * @param args the arguments to be parsed.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SearchAnimalCommand parse(String args) throws ParseException {
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, MANDATORY_PREFIXES);
+
+        if (!ArgumentMultimap.areSomePrefixesPresent(argMultimap, MANDATORY_PREFIXES)) {
+            throw new ParseException(getHelpMessage());
+        }
+
+        // ParseException containing the duplicated prefixes separated by whitespace is thrown.
+        argMultimap.verifyNoDuplicatePrefixesFor(MANDATORY_PREFIXES);
+
+        //Obtain values of the different fields
+        String name = argMultimap.getValue(NAME).orElse("");
+        String id = argMultimap.getValue(PET_ID).orElse("");
+        String dob = argMultimap.getValue(DATE_OF_BIRTH).orElse("");
+        String doa = argMultimap.getValue(DATE_OF_ADMISSION).orElse("");
+        String species = argMultimap.getValue(SPECIES).orElse("");
+        String sex = argMultimap.getValue(SEX).orElse("");
+        String breed = argMultimap.getValue(BREED).orElse("");
+
+
+        List<String> keywords = Arrays.asList(name, id, dob, doa, species, sex, breed);
+
+        //Remove empty fields
+        keywords = keywords.stream()
+                .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
+
+        //keywords should not be empty
+        assert(!keywords.isEmpty());
+
+        return new SearchAnimalCommand(new KeywordPredicate(keywords));
+    }
+
+    private static String getHelpMessage() {
+        return AnimalMessages.getFormattedHelpMessage(AnimalMessages.MESSAGE_INVALID_SEARCH_KEYWORDS,
+                SearchAnimalCommand.EXAMPLE_USAGE);
+    }
+}

--- a/src/main/java/seedu/address/model/animal/KeywordPredicate.java
+++ b/src/main/java/seedu/address/model/animal/KeywordPredicate.java
@@ -1,8 +1,10 @@
 package seedu.address.model.animal;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
@@ -19,15 +21,33 @@ public class KeywordPredicate implements Predicate<Animal> {
 
     @Override
     public boolean test(Animal animal) {
-        return keywords.stream().allMatch(keyword ->
-                StringUtil.containsWordIgnoreCase(animal.getNameForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getPetIdForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getDateOfBirthForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getAdmissionDateForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getSpeciesForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getSexForSerialization(), keyword)
-                        || StringUtil.containsWordIgnoreCase(animal.getBreedForSerialization(), keyword)
-        );
+
+        List<String> stringAttributes = new ArrayList<>(List.of(
+                animal.getNameForSerialization(),
+                animal.getPetIdForSerialization(),
+                animal.getDateOfBirthForSerialization(),
+                animal.getAdmissionDateForSerialization(),
+                animal.getSpeciesForSerialization(),
+                animal.getSexForSerialization(),
+                animal.getBreedForSerialization()
+        ));
+
+        assert(keywords.size() == stringAttributes.size());
+
+        List<String> keywordsCopy = new ArrayList<>(keywords);
+        keywordsCopy = keywordsCopy.stream()
+                .filter(keyword -> !keyword.isEmpty()).collect(Collectors.toList());
+        assert(!keywordsCopy.isEmpty());
+
+        return keywords.stream().allMatch(keyword -> {
+            if (keyword.isEmpty()) {
+                stringAttributes.remove(0);
+                return true;
+            } else {
+                String attribute = stringAttributes.remove(0);
+                return StringUtil.containsWordIgnoreCase(attribute, keyword);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/seedu/address/model/animal/KeywordPredicate.java
+++ b/src/main/java/seedu/address/model/animal/KeywordPredicate.java
@@ -1,0 +1,49 @@
+package seedu.address.model.animal;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Animal}'s {@code Name} matches any of the keywords given.
+ */
+public class KeywordPredicate implements Predicate<Animal> {
+    private final List<String> keywords;
+
+    public KeywordPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Animal animal) {
+        return keywords.stream().allMatch(keyword ->
+                StringUtil.containsWordIgnoreCase(animal.getNameForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getPetIdForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getDateOfBirthForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getAdmissionDateForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getSpeciesForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getSexForSerialization(), keyword)
+                        || StringUtil.containsWordIgnoreCase(animal.getBreedForSerialization(), keyword)
+        );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof KeywordPredicate // instanceof handles nulls
+                && keywords.equals(((KeywordPredicate) other).keywords)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/data/JsonSerializableAnimalCatalogTest/typicalAnimalsCatalog.json
+++ b/src/test/data/JsonSerializableAnimalCatalogTest/typicalAnimalsCatalog.json
@@ -32,5 +32,13 @@
     "breed" : "Good Boy",
     "dateOfBirth" : "2001-01-01",
     "admissionDate" : "2023-02-02"
+  }, {
+    "name" : "Bear",
+    "petId" : "1111",
+    "sex" : "FEMALE",
+    "species" : "Dog",
+    "breed" : "Poodle",
+    "dateOfBirth" : "2019-01-01",
+    "admissionDate" : "2019-01-01"
   } ]
 }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -63,7 +63,7 @@ public class StringUtilTest {
 
     @Test
     public void containsWordIgnoreCase_emptyWord_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter cannot be empty", ()
+        assertThrows(IllegalArgumentException.class, "Phrase parameter cannot be empty", ()
             -> StringUtil.containsWordIgnoreCase("typical sentence", "  "));
     }
 
@@ -123,6 +123,10 @@ public class StringUtilTest {
                 "bbb cc")); //Sentence phrase bigger then query phrase
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb",
                 "cccc bb")); //Query phrase bigger then sentence phrase
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb",
+                "bb ccc")); //Query phrase is part of sentence phrase
+        assertFalse(StringUtil.containsWordIgnoreCase("bb",
+                "bb cc")); //Sentence phrase is shorter than query phrase
 
         // Matches phrase in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb! ccc bb", "aAa BBB!")); //First phrase

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -119,13 +119,16 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
 
         //Matches partial phrase in sentence
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "bbb cc")); //Sentence phrase bigger then query phrase
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "cccc bb")); //Query phrase bigger then sentence phrase
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb",
+                "bbb cc")); //Sentence phrase bigger then query phrase
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb",
+                "cccc bb")); //Query phrase bigger then sentence phrase
 
         // Matches phrase in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb! ccc bb", "aAa BBB!")); //First phrase
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb c1c bb", "C1C bB")); //Last phrase
-        assertTrue(StringUtil.containsWordIgnoreCase("aaa    bbb    ccc  bb", "aaa bbb ccc bb")); //Sentence has extra spaces
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa    bbb    ccc  bb",
+                "aaa bbb ccc bb")); //Sentence has extra spaces
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "aaa bbb ccc bb")); //Only one phrase in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "   bb  ")); //Leading/trailing spaces
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -51,7 +51,7 @@ public class StringUtilTest {
     //---------------- Tests for containsWordIgnoreCase --------------------------------------
 
     /*
-     * Invalid equivalence partitions for word: null, empty, multiple words
+     * Invalid equivalence partitions for word: null, empty
      * Invalid equivalence partitions for sentence: null
      * The four test cases below test one invalid input at a time.
      */
@@ -68,18 +68,12 @@ public class StringUtilTest {
     }
 
     @Test
-    public void containsWordIgnoreCase_multipleWords_throwsIllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class, "Word parameter should be a single word", ()
-            -> StringUtil.containsWordIgnoreCase("typical sentence", "aaa BBB"));
-    }
-
-    @Test
     public void containsWordIgnoreCase_nullSentence_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> StringUtil.containsWordIgnoreCase(null, "abc"));
     }
 
     /*
-     * Valid equivalence partitions for word:
+     * Valid equivalence partitions for word/phrase:
      *   - any word
      *   - word containing symbols/numbers
      *   - word with leading/trailing spaces
@@ -123,6 +117,21 @@ public class StringUtilTest {
 
         // Matches multiple words in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
+
+        //Matches partial phrase in sentence
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "bbb cc")); //Sentence phrase bigger then query phrase
+        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "cccc bb")); //Query phrase bigger then sentence phrase
+
+        // Matches phrase in sentence
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb! ccc bb", "aAa BBB!")); //First phrase
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb c1c bb", "C1C bB")); //Last phrase
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa    bbb    ccc  bb", "aaa bbb ccc bb")); //Sentence has extra spaces
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "aaa bbb ccc bb")); //Only one phrase in sentence
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc bb", "   bb  ")); //Leading/trailing spaces
+
+        //Matches multiple phrases in sentence
+        assertTrue(StringUtil.containsWordIgnoreCase("AAA bbb ccc  bbb   CCC   ", "bbB cCc"));
+
     }
 
     //---------------- Tests for getDetails --------------------------------------

--- a/src/test/java/seedu/address/logic/commands/SearchAnimalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchAnimalCommandTest.java
@@ -1,0 +1,98 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.AnimalCommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalAnimals.getTypicalCatalog;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AnimalModel;
+import seedu.address.model.AnimalModelManager;
+import seedu.address.model.AnimalUserPrefs;
+import seedu.address.model.animal.KeywordPredicate;
+
+public class SearchAnimalCommandTest {
+
+    private AnimalModel model = new AnimalModelManager(getTypicalCatalog(), new AnimalUserPrefs());
+    private AnimalModel expectedModel = new AnimalModelManager(getTypicalCatalog(), new AnimalUserPrefs());
+
+    private KeywordPredicate firstPredicate = new KeywordPredicate(List.of("Tofu"));
+    private KeywordPredicate secondPredicate = new KeywordPredicate(List.of("Muffin"));
+    private SearchAnimalCommand searchFirstAnimalCommand = new SearchAnimalCommand(firstPredicate);
+    private SearchAnimalCommand searchSecondAnimalCommand = new SearchAnimalCommand(secondPredicate);
+
+
+    @Test
+    public void equals_sameCommand_returnsTrue() {
+        assertTrue(searchFirstAnimalCommand.equals(searchFirstAnimalCommand));
+    }
+
+    @Test
+    public void equals_sameValues_returnsTrue() {
+        SearchAnimalCommand searchFirstAnimalCommandCopy = new SearchAnimalCommand(firstPredicate);
+        assertTrue(searchFirstAnimalCommand.equals(searchFirstAnimalCommandCopy));
+    }
+
+    @Test
+    public void equals_differentCommand_returnsFalse() {
+        assertFalse(searchFirstAnimalCommand.equals(searchSecondAnimalCommand));
+    }
+
+    @Test
+    public void equals_differentTypes_returnsFalse() {
+        assertFalse(searchFirstAnimalCommand.equals(1));
+    }
+
+    @Test
+    public void equals_nullCommand_returnsFalse() {
+        assertFalse(searchFirstAnimalCommand.equals(null));
+    }
+
+    @Test
+    public void equals_nullOtherCommand_returnsFalse() {
+        assertThrows(NullPointerException.class, () -> ((SearchAnimalCommand) null).equals(searchFirstAnimalCommand));
+    }
+
+    @Test
+    public void execute_allKeywords_oneAnimalFound() {
+        String expectedMessage = String.format(SearchAnimalCommand.MESSAGE_SUCCESS, 1);
+        KeywordPredicate predicate = new KeywordPredicate(List.of("Tofu", "1234", "2019-10-10",
+                "2019-11-11", "cat", "female", "british shorthair"));
+        SearchAnimalCommand command = new SearchAnimalCommand(predicate);
+        expectedModel.updateFilteredAnimalList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredAnimalList().size() == 1);
+    }
+
+    @Test
+    public void execute_someKeywords_someAnimalsFound() {
+        // Only 1 animal found
+        String expectedMessage = String.format(SearchAnimalCommand.MESSAGE_SUCCESS, 1);
+        KeywordPredicate predicate = new KeywordPredicate(List.of("Tofu", "", "", "", "", "", ""));
+        SearchAnimalCommand command = new SearchAnimalCommand(predicate);
+        expectedModel.updateFilteredAnimalList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredAnimalList().size() == 1);
+
+        // More than 1 animal found
+        expectedMessage = String.format(SearchAnimalCommand.MESSAGE_SUCCESS, 3);
+        predicate = new KeywordPredicate(List.of("", "", "", "", "", "male", ""));
+        command = new SearchAnimalCommand(predicate);
+        expectedModel.updateFilteredAnimalList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredAnimalList().size() == 3);
+
+        // Only animal with matching breed is found
+        expectedMessage = String.format(SearchAnimalCommand.MESSAGE_SUCCESS, 1);
+        predicate = new KeywordPredicate(List.of("", "", "", "", "", "", "Bear"));
+        command = new SearchAnimalCommand(predicate);
+        expectedModel.updateFilteredAnimalList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredAnimalList().size() == 1);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -200,6 +200,42 @@ public class ArgumentTokenizerTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void areSomePrefixesPresent_withPresentPrefixes_returnTrue() {
+        // All prefixes present
+        String argsString = "SomePreambleString p/pSlash -t dashT ^Q hatQ";
+        ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+
+        assertTrue(ArgumentMultimap.areSomePrefixesPresent(argMultiMap, pSlash, dashT, hatQ));
+
+        // Some prefixes present
+        argsString = "SomePreambleString p/pSlash ^Q hatQ";
+        argMultiMap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+
+        assertTrue(ArgumentMultimap.areSomePrefixesPresent(argMultiMap, pSlash, dashT, hatQ));
+
+        // Only one prefix present
+        argsString = "SomePreambleString p/pSlash";
+        argMultiMap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+
+        assertTrue(ArgumentMultimap.areSomePrefixesPresent(argMultiMap, pSlash, dashT, hatQ));
+    }
+
+    @Test
+    public void areSomePrefixesPresent_missingPrefix_returnFalse() {
+        // No prefixes present
+        String argsString = "SomePreambleString";
+        ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+
+        assertFalse(ArgumentMultimap.areSomePrefixesPresent(argMultiMap, pSlash, dashT, hatQ));
+
+        // Only unknown prefix present
+        argsString = "SomePreambleString --u";
+        argMultiMap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+
+        assertFalse(ArgumentMultimap.areSomePrefixesPresent(argMultiMap, pSlash, dashT, hatQ));
+    }
+
 
     @Test
     public void equalsMethod() {

--- a/src/test/java/seedu/address/logic/parser/SearchAnimalCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchAnimalCommandParserTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.parser.AnimalCommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.AnimalCommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.AnimalMessages;
+import seedu.address.logic.commands.SearchAnimalCommand;
+
+public class SearchAnimalCommandParserTest {
+    private SearchAnimalCommandParser parser = new SearchAnimalCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                AnimalMessages.getFormattedHelpMessage(AnimalMessages.MESSAGE_INVALID_SEARCH_KEYWORDS,
+                SearchAnimalCommand.EXAMPLE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "bob", AnimalMessages.getFormattedHelpMessage(
+                AnimalMessages.MESSAGE_INVALID_SEARCH_KEYWORDS,
+                SearchAnimalCommand.EXAMPLE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        try {
+            // no leading and trailing whitespaces
+            SearchAnimalCommand expectedSearchAnimalCommand =
+                    new SearchAnimalCommandParser().parse(" n/Pookie");
+            assertParseSuccess(parser, " n/Pookie", expectedSearchAnimalCommand);
+
+            // multiple prefixes
+            expectedSearchAnimalCommand =
+                    new SearchAnimalCommandParser().parse(" n/Pookie id/1234");
+            assertParseSuccess(parser, " n/Pookie id/1234", expectedSearchAnimalCommand);
+
+            // different order of prefixes
+            expectedSearchAnimalCommand =
+                    new SearchAnimalCommandParser().parse(" id/1234 n/Pookie");
+            assertParseSuccess(parser, " id/1234 n/Pookie", expectedSearchAnimalCommand);
+        } catch (Exception e) {
+            fail("Exception should not be thrown");
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/animal/KeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/animal/KeywordPredicateTest.java
@@ -54,154 +54,178 @@ public class KeywordPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One word
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu", "", "", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withName("Tofu").build()));
 
         // Multiple words
-        predicate = new KeywordPredicate(Arrays.asList("Tofu", "Muffin"));
+        predicate = new KeywordPredicate(Arrays.asList("Tofu Muffin", "", "", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
 
         // Mixed-case keywords
-        predicate = new KeywordPredicate(Arrays.asList("tOfU", "mUfFin"));
+        predicate = new KeywordPredicate(Arrays.asList("tOfU mUfFin", "", "", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
 
         // Trailing spaces in keywords
-        predicate = new KeywordPredicate(Arrays.asList("Tofu ", " Muffin"));
+        predicate = new KeywordPredicate(Arrays.asList("Tofu  Muffin", "", "", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Partial keywords
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu Muffin"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu Muffin", "", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withName("Tofu Muff").build()));
 
         // Only one matching keyword
-        predicate = new KeywordPredicate(Arrays.asList("Tofu", "Muffin"));
+        predicate = new KeywordPredicate(Arrays.asList("Tofu Muffin", "", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withName("Tofu").build()));
 
         // Non-matching keywords
-        predicate = new KeywordPredicate(Arrays.asList("Tofu"));
+        predicate = new KeywordPredicate(Arrays.asList("Tofu", "", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withName("Muffin").build()));
     }
 
     @Test
     public void test_petIdContainsKeywords_returnTrue() {
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("1234"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("", "1234", "", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withPetId("1234").build()));
     }
 
     @Test
     public void test_petIdDoesNotContainKeywords_returnFalse() {
         // Partial keywords
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("123"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("", "123", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
 
         // Non-matching keywords
-        predicate = new KeywordPredicate(Arrays.asList("9876"));
+        predicate = new KeywordPredicate(Arrays.asList("", "9876", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
 
-        predicate = new KeywordPredicate(Arrays.asList("nonInteger"));
+        predicate = new KeywordPredicate(Arrays.asList("", "nonInteger", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
 
         // Longer keyword
-        predicate = new KeywordPredicate(Arrays.asList("12345"));
+        predicate = new KeywordPredicate(Arrays.asList("", "12345", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
 
         // Spaces in keyword
-        predicate = new KeywordPredicate(Arrays.asList("1 2 3 4"));
+        predicate = new KeywordPredicate(Arrays.asList("", "1 2 3 4", "", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
     }
 
     @Test
     public void test_dateContainsKeywords_returnTrue() {
         // Matching date
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("2020-01-01"));
+        KeywordPredicate predicate = new KeywordPredicate(
+                Arrays.asList("", "", "2020-01-01", "", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "2020-01-01", "", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
     }
 
     @Test
     public void test_dateDoesNotContainKeywords_returnFalse() {
         // Non-matching date
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("2020-01-01"));
+        KeywordPredicate predicate = new KeywordPredicate(
+                Arrays.asList("", "", "2020-01-01", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-02").build()));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "2020-01-01", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-02").build()));
 
         // Partial keywords
-        predicate = new KeywordPredicate(Arrays.asList("2020-01"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "2020-01", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-02").build()));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "2020-01", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-02").build()));
 
         // Longer keyword
-        predicate = new KeywordPredicate(Arrays.asList("2020-01-01-01"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "2020-01-01-01", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "2020-01-01-01", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
 
         // Spaces in keyword
-        predicate = new KeywordPredicate(Arrays.asList("2020- 01- 01"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "2020 -01 -01", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "2020 -01 -01", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
 
         // Non-date keyword
-        predicate = new KeywordPredicate(Arrays.asList("nonDate"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "nonDate", "", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "nonDate", "", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
     }
 
     @Test
     public void test_speciesContainsKeywords_returnTrue() {
         // Matching species
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("cat"));
+        KeywordPredicate predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "", "cat", "", ""));
         assertTrue(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
     }
 
     @Test
     public void test_speciesDoesNotContainKeyword_returnFalse() {
         // Non-matching species
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("cat"));
+        KeywordPredicate predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "", "cat", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withSpecies("dog").build()));
 
         // Partial keywords
-        predicate = new KeywordPredicate(Arrays.asList("ca"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "", "ca", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
 
         // Longer keyword
-        predicate = new KeywordPredicate(Arrays.asList("cats"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "", "cats", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
 
         // Spaces in keyword
-        predicate = new KeywordPredicate(Arrays.asList("c a t"));
+        predicate = new KeywordPredicate(
+                Arrays.asList("", "", "", "", "c a t", "", ""));
         assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
     }
 
     @Test
     public void test_breedContainsKeywords_returnTrue() {
         // Matching breed
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("persian"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "persian"));
         assertTrue(predicate.test(new AnimalBuilder().withBreed("persian").build()));
 
         // Matching breed with multiple words
-        predicate = new KeywordPredicate(Arrays.asList("golden retriever"));
+        predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "golden retriever"));
         assertTrue(predicate.test(new AnimalBuilder().withBreed("golden retriever").build()));
     }
 
     @Test
     public void test_breedDoesNotContainKeywords_returnFalse() {
         // Non-matching breed
-        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("persian"));
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "persian"));
         assertFalse(predicate.test(new AnimalBuilder().withBreed("ragdoll").build()));
 
         // Partial keywords
-        predicate = new KeywordPredicate(Arrays.asList("persi"));
+        predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "persi"));
         assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
 
         // Longer keyword
-        predicate = new KeywordPredicate(Arrays.asList("persians"));
+        predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "persians"));
         assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
 
         // Spaces in keyword
-        predicate = new KeywordPredicate(Arrays.asList("p e r s i a n"));
+        predicate = new KeywordPredicate(Arrays.asList("", "", "", "", "", "", "p e r s i a n"));
         assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
     }
 

--- a/src/test/java/seedu/address/model/animal/KeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/animal/KeywordPredicateTest.java
@@ -1,0 +1,216 @@
+package seedu.address.model.animal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.AnimalBuilder;
+
+
+public class KeywordPredicateTest {
+
+    private List<String> firstPredicateKeywordList = List.of("first");
+    private List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+    private KeywordPredicate firstPredicate = new KeywordPredicate(firstPredicateKeywordList);
+    private KeywordPredicate secondPredicate = new KeywordPredicate(secondPredicateKeywordList);
+
+    @Test
+    public void equals_samePredicate_returnsTrue() {
+        assertTrue(firstPredicate.equals(firstPredicate));
+    }
+
+    @Test
+    public void equals_sameValues_returnsTrue() {
+        KeywordPredicate firstPredicateCopy = new KeywordPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+    }
+
+    @Test
+    public void equals_nullOtherPredicate_returnsFalse() {
+        assertFalse(firstPredicate.equals(null));
+    }
+
+    @Test
+    public void equals_null_returnsFalse() {
+        assertThrows(NullPointerException.class, () -> ((KeywordPredicate) null).equals(firstPredicate));
+    }
+
+    @Test
+    public void equals_differentTypes_returnsFalse() {
+        assertFalse(firstPredicate.equals(1));
+    }
+
+    @Test
+    public void equals_differentPredicate_returnsFalse() {
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One word
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu"));
+        assertTrue(predicate.test(new AnimalBuilder().withName("Tofu").build()));
+
+        // Multiple words
+        predicate = new KeywordPredicate(Arrays.asList("Tofu", "Muffin"));
+        assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
+
+        // Mixed-case keywords
+        predicate = new KeywordPredicate(Arrays.asList("tOfU", "mUfFin"));
+        assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
+
+        // Trailing spaces in keywords
+        predicate = new KeywordPredicate(Arrays.asList("Tofu ", " Muffin"));
+        assertTrue(predicate.test(new AnimalBuilder().withName("Tofu Muffin").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        // Partial keywords
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("Tofu Muffin"));
+        assertFalse(predicate.test(new AnimalBuilder().withName("Tofu Muff").build()));
+
+        // Only one matching keyword
+        predicate = new KeywordPredicate(Arrays.asList("Tofu", "Muffin"));
+        assertFalse(predicate.test(new AnimalBuilder().withName("Tofu").build()));
+
+        // Non-matching keywords
+        predicate = new KeywordPredicate(Arrays.asList("Tofu"));
+        assertFalse(predicate.test(new AnimalBuilder().withName("Muffin").build()));
+    }
+
+    @Test
+    public void test_petIdContainsKeywords_returnTrue() {
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("1234"));
+        assertTrue(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+    }
+
+    @Test
+    public void test_petIdDoesNotContainKeywords_returnFalse() {
+        // Partial keywords
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("123"));
+        assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+
+        // Non-matching keywords
+        predicate = new KeywordPredicate(Arrays.asList("9876"));
+        assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+
+        predicate = new KeywordPredicate(Arrays.asList("nonInteger"));
+        assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+
+        // Longer keyword
+        predicate = new KeywordPredicate(Arrays.asList("12345"));
+        assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+
+        // Spaces in keyword
+        predicate = new KeywordPredicate(Arrays.asList("1 2 3 4"));
+        assertFalse(predicate.test(new AnimalBuilder().withPetId("1234").build()));
+    }
+
+    @Test
+    public void test_dateContainsKeywords_returnTrue() {
+        // Matching date
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("2020-01-01"));
+        assertTrue(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        assertTrue(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
+    }
+
+    @Test
+    public void test_dateDoesNotContainKeywords_returnFalse() {
+        // Non-matching date
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("2020-01-01"));
+        assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-02").build()));
+        assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-02").build()));
+
+        // Partial keywords
+        predicate = new KeywordPredicate(Arrays.asList("2020-01"));
+        assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-02").build()));
+        assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-02").build()));
+
+        // Longer keyword
+        predicate = new KeywordPredicate(Arrays.asList("2020-01-01-01"));
+        assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
+
+        // Spaces in keyword
+        predicate = new KeywordPredicate(Arrays.asList("2020- 01- 01"));
+        assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
+
+        // Non-date keyword
+        predicate = new KeywordPredicate(Arrays.asList("nonDate"));
+        assertFalse(predicate.test(new AnimalBuilder().withDateOfBirth("2020-01-01").build()));
+        assertFalse(predicate.test(new AnimalBuilder().withAdmissionDate("2020-01-01").build()));
+    }
+
+    @Test
+    public void test_speciesContainsKeywords_returnTrue() {
+        // Matching species
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("cat"));
+        assertTrue(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
+    }
+
+    @Test
+    public void test_speciesDoesNotContainKeyword_returnFalse() {
+        // Non-matching species
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("cat"));
+        assertFalse(predicate.test(new AnimalBuilder().withSpecies("dog").build()));
+
+        // Partial keywords
+        predicate = new KeywordPredicate(Arrays.asList("ca"));
+        assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
+
+        // Longer keyword
+        predicate = new KeywordPredicate(Arrays.asList("cats"));
+        assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
+
+        // Spaces in keyword
+        predicate = new KeywordPredicate(Arrays.asList("c a t"));
+        assertFalse(predicate.test(new AnimalBuilder().withSpecies("cat").build()));
+    }
+
+    @Test
+    public void test_breedContainsKeywords_returnTrue() {
+        // Matching breed
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("persian"));
+        assertTrue(predicate.test(new AnimalBuilder().withBreed("persian").build()));
+
+        // Matching breed with multiple words
+        predicate = new KeywordPredicate(Arrays.asList("golden retriever"));
+        assertTrue(predicate.test(new AnimalBuilder().withBreed("golden retriever").build()));
+    }
+
+    @Test
+    public void test_breedDoesNotContainKeywords_returnFalse() {
+        // Non-matching breed
+        KeywordPredicate predicate = new KeywordPredicate(Arrays.asList("persian"));
+        assertFalse(predicate.test(new AnimalBuilder().withBreed("ragdoll").build()));
+
+        // Partial keywords
+        predicate = new KeywordPredicate(Arrays.asList("persi"));
+        assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
+
+        // Longer keyword
+        predicate = new KeywordPredicate(Arrays.asList("persians"));
+        assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
+
+        // Spaces in keyword
+        predicate = new KeywordPredicate(Arrays.asList("p e r s i a n"));
+        assertFalse(predicate.test(new AnimalBuilder().withBreed("persian").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        KeywordPredicate predicate = new KeywordPredicate(keywords);
+
+        String expectedString = KeywordPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expectedString, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalAnimals.java
+++ b/src/test/java/seedu/address/testutil/TypicalAnimals.java
@@ -52,6 +52,16 @@ public class TypicalAnimals {
         .withAdmissionDate("2023-02-02")
         .build();
 
+    public static final Animal BEAR = new AnimalBuilder()
+            .withName("Bear")
+            .withPetId("1111")
+            .withSex("Female")
+            .withSpecies("Dog")
+            .withBreed("Poodle")
+            .withDateOfBirth("2019-01-01")
+            .withAdmissionDate("2019-01-01")
+            .build();
+
     public static AnimalCatalog getTypicalCatalog() {
         AnimalCatalog ac = new AnimalCatalog();
         for (Animal animal : getTypicalAnimals()) {
@@ -61,6 +71,6 @@ public class TypicalAnimals {
     }
 
     public static List<Animal> getTypicalAnimals() {
-        return new ArrayList<>(Arrays.asList(TOFU, MUFFIN, JAEBEE, LOYBOY));
+        return new ArrayList<>(Arrays.asList(TOFU, MUFFIN, JAEBEE, LOYBOY, BEAR));
     }
 }


### PR DESCRIPTION
Add Search Animal Command. How it works:
- search by name, petid, species, breed, sex, date of birth or/and admission date using the same prefix as add animal
- there must be at least 1 prefix
- if searching by more than 1 prefix, the animal's attribute has to match all the specified fields eg search b/dog n/tofu will only return a dog named tofu and not any other dog or any pet named tofu
- the order of prefix does not matter

Edit containsWordIgnoreCase in StringUtil.java
- It can check for both word or phrases in sentences instead of just a word