### PR TITLE
Fix mark, unmark and reset command bugs

### DIFF
--- a/src/main/java/seedu/address/logic/AnimalMessages.java
+++ b/src/main/java/seedu/address/logic/AnimalMessages.java
@@ -27,6 +27,12 @@ public class AnimalMessages {
 
     public static final String MESSAGE_MISSING_ANIMAL_INDEX = "Animal index is missing!";
     public static final String MESSAGE_MISSING_TASK_INDEX = "Task index(s) is/are missing!";
+    public static final String MESSAGE_NEGATIVE_INDEX = "Index cannot be negative! "
+            + "Please provide a positive integer index.";
+    public static final String MESSAGE_INVALID_DOUBLE_INDEX = "Index must be an integer! "
+            + "Please provide a positive integer index.";
+    public static final String MESSAGE_INVALID_STRING_INDEX = "Index cannot be a word! "
+            + "Please provide a positive integer index.";
 
 
     // ------------------------------------- Format Strings -----------------------------------------------

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_ANIMAL_DISPLAYED_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 
 import java.util.List;
 
@@ -77,7 +78,17 @@ public class MarkTaskCommand extends AnimalCommand {
             int[] taskIndexes = stream(taskIndex)
                     .map(Index::getZeroBased)
                     .mapToInt(Integer::intValue)
+                    .sorted()
                     .toArray();
+
+            assert taskIndexes.length > 0 : "taskIndexes should not be empty";
+
+            assert taskIndexes[0] >= 0 : "taskIndexes should not be negative";
+
+            // check if index provided exceeds number of tasks
+            if (taskIndexes[taskIndex.length - 1] > animalToMark.getNumberOfTasks() - 1) {
+                throw new CommandException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+            }
 
             Animal markedAnimal = createEditedAnimal(animalToMark, taskIndexes);
 
@@ -85,6 +96,7 @@ public class MarkTaskCommand extends AnimalCommand {
             model.updateFilteredAnimalList(AnimalModel.PREDICATE_SHOW_ALL_ANIMALS);
 
             return new CommandResult(MESSAGE_SUCCESS);
+
         } catch (IndexOutOfBoundsException e) {
             throw new CommandException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkTaskCommand.java
@@ -2,8 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_ANIMAL_DISPLAYED_INDEX;
-import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 
 import java.util.List;
 
@@ -43,6 +41,11 @@ public class MarkTaskCommand extends AnimalCommand {
 
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
 
+    public static final String MESSAGE_EXCESS_TASK_INDEX =
+            "The task index(es) provided exceeds the number of tasks in the animal!";
+
+    public static final String MESSAGE_EXCESS_ANIMAL_INDEX = "The animal index provided exceeds the number of animals!";
+
     private final Index targetIndex;
     private final Index[] taskIndex;
 
@@ -70,7 +73,7 @@ public class MarkTaskCommand extends AnimalCommand {
         List<Animal> lastShownList = model.getFilteredAnimalList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(MESSAGE_INVALID_ANIMAL_DISPLAYED_INDEX);
+            throw new CommandException(MESSAGE_EXCESS_ANIMAL_INDEX);
         }
 
         Animal animalToMark = lastShownList.get(targetIndex.getZeroBased());
@@ -87,7 +90,7 @@ public class MarkTaskCommand extends AnimalCommand {
 
             // check if index provided exceeds number of tasks
             if (taskIndexes[taskIndex.length - 1] > animalToMark.getNumberOfTasks() - 1) {
-                throw new CommandException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+                throw new CommandException(MESSAGE_EXCESS_TASK_INDEX);
             }
 
             Animal markedAnimal = createEditedAnimal(animalToMark, taskIndexes);

--- a/src/main/java/seedu/address/logic/commands/ResetTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ResetTaskCommand.java
@@ -16,8 +16,7 @@ public class ResetTaskCommand extends AnimalCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Resets all tasks of the animal, identified by the index number "
-            + "used in the displayed animal list, as uncompleted. "
-            + "\nParameters: ANIMAL_INDEX (must be a positive integer)";
+            + "used in the displayed animal list, as uncompleted. ";
 
     public static final String EXAMPLE_USAGE = "Example: " + COMMAND_WORD;
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -72,7 +72,7 @@ public class UnmarkTaskCommand extends AnimalCommand {
         requireNonNull(model);
         List<Animal> lastShownList = model.getFilteredAnimalList();
 
-
+        // check if animal index provided exceeds number of animals
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(MESSAGE_EXCESS_ANIMAL_INDEX);
         }
@@ -92,7 +92,7 @@ public class UnmarkTaskCommand extends AnimalCommand {
 
             // check if index provided exceeds number of tasks
             if (taskIndexes[taskIndex.length - 1] > animalToMark.getNumberOfTasks() - 1) {
-                throw new CommandException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+                throw new CommandException(MESSAGE_EXCESS_TASK_INDEX);
             }
 
             Animal editedAnimal = createEditedAnimal(animalToMark, taskIndexes);

--- a/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkTaskCommand.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_ANIMAL_DISPLAYED_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ public class UnmarkTaskCommand extends AnimalCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Unmarks a task of the animal, identified by the index number "
             + "used in the displayed animal list, as uncompleted. "
-            + "\nParameters: ANIMAL_INDEX (must be a positive integer)"
+            + "\nParameters: ANIMAL_INDEX (must be a positive integer) "
             + "TASK_INDEX (must be a positive integer)";
 
     public static final String EXAMPLE_USAGE = "Example: "
@@ -40,14 +40,17 @@ public class UnmarkTaskCommand extends AnimalCommand {
 
     public static final String MESSAGE_SUCCESS = "Task(s) marked as uncompleted";
 
-    public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
+    public static final String MESSAGE_EXCESS_TASK_INDEX =
+            "The task index(es) provided exceeds the number of tasks in the animal!";
+
+    public static final String MESSAGE_EXCESS_ANIMAL_INDEX = "The animal index provided exceeds the number of animals!";
 
     private final Index targetIndex;
 
     private final Index[] taskIndex;
 
     /**
-     * Creates a MarkTaskCommand to mark the specified {@code Task} of the {@code Animal} at the specified
+     * Creates a UnmarkTaskCommand to unmark the specified {@code Task} of the {@code Animal} at the specified
      * {@code Index}.
      */
     public UnmarkTaskCommand(Index targetIndex, Index... taskIndex) {
@@ -71,7 +74,7 @@ public class UnmarkTaskCommand extends AnimalCommand {
 
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(MESSAGE_INVALID_ANIMAL_DISPLAYED_INDEX);
+            throw new CommandException(MESSAGE_EXCESS_ANIMAL_INDEX);
         }
 
         Animal animalToMark = lastShownList.get(targetIndex.getZeroBased());
@@ -80,7 +83,17 @@ public class UnmarkTaskCommand extends AnimalCommand {
             int[] taskIndexes = stream(taskIndex)
                     .map(Index::getZeroBased)
                     .mapToInt(Integer::intValue)
+                    .sorted()
                     .toArray();
+
+            assert taskIndexes.length > 0 : "taskIndexes should not be empty";
+
+            assert taskIndexes[0] >= 0 : "taskIndexes should not be negative";
+
+            // check if index provided exceeds number of tasks
+            if (taskIndexes[taskIndex.length - 1] > animalToMark.getNumberOfTasks() - 1) {
+                throw new CommandException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+            }
 
             Animal editedAnimal = createEditedAnimal(animalToMark, taskIndexes);
             model.setAnimal(animalToMark, editedAnimal);

--- a/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Arrays.stream;
-import static seedu.address.logic.AnimalMessages.*;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_DOUBLE_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_STRING_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_ANIMAL_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_TASK_INDEX;
 import static seedu.address.logic.AnimalMessages.MESSAGE_NEGATIVE_INDEX;
 
 import java.util.logging.Logger;

--- a/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkTaskCommandParser.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Arrays.stream;
-import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_ANIMAL_INDEX;
-import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_TASK_INDEX;
+import static seedu.address.logic.AnimalMessages.*;
+import static seedu.address.logic.AnimalMessages.MESSAGE_NEGATIVE_INDEX;
 
 import java.util.logging.Logger;
 
@@ -37,14 +37,55 @@ public class MarkTaskCommandParser implements AnimalParser<MarkTaskCommand> {
 
         String[] indexLists = trimmedArgs.split("\\s+", 2);
 
+        // checks if animal index is a number
+        if (!indexLists[0].matches("\\d+")) {
+            throw new ParseException("Animal " + MESSAGE_INVALID_STRING_INDEX);
+        }
+
+        // checks if animal index is an integer
+        if (Double.parseDouble(indexLists[0]) % 1 != 0) {
+            throw new ParseException("Animal " + MESSAGE_INVALID_DOUBLE_INDEX);
+        }
+
+        int animalIntIndex = Integer.parseInt(indexLists[0]);
+
+        // checks if animal index provided is negative
+        if (animalIntIndex <= 0) {
+            throw new ParseException("Animal " + MESSAGE_NEGATIVE_INDEX);
+        }
+
+
+        // checks to ensure task indexes provided are valid
+
+        // checks if task indexes provided are numbers
+        if (!indexLists[1].matches("\\d+(\\s+\\d+)*")) {
+            throw new ParseException("Task " + MESSAGE_INVALID_STRING_INDEX);
+        }
+
+        double[] checkTaskIndexes = stream(indexLists[1].split("\\s+"))
+                .map(Double::parseDouble)
+                .mapToDouble(Double::doubleValue)
+                .toArray();
+
+        // check if indexes provided are negative
+        if (stream(checkTaskIndexes).anyMatch(index -> index <= 0)) {
+            throw new ParseException("Task " + MESSAGE_NEGATIVE_INDEX);
+        }
+
+        // check if indexes provided are integers
+        if (stream(checkTaskIndexes).anyMatch(index -> index % 1 != 0)) {
+            throw new ParseException("Task " + MESSAGE_INVALID_DOUBLE_INDEX);
+        }
+
+
         Index animalIndex = Index.fromOneBased(Integer.parseInt(indexLists[0]));
-        Index[] taskIndex = stream(indexLists[1].split("\\s+"))
+        Index[] taskIndexes = stream(indexLists[1].split("\\s+"))
                 .map(Integer::parseInt)
                 .map(Index::fromOneBased)
                 .toArray(Index[]::new);
 
 
-        return new MarkTaskCommand(animalIndex, taskIndex);
+        return new MarkTaskCommand(animalIndex, taskIndexes);
     }
 
     private static String getAnimalHelpMessage() {

--- a/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
@@ -1,15 +1,13 @@
 package seedu.address.logic.parser;
 
 import static java.util.Arrays.stream;
-import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_ANIMAL_INDEX;
-import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_TASK_INDEX;
+import static seedu.address.logic.AnimalMessages.*;
 
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.AnimalMessages;
-import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.commands.UnmarkTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -37,23 +35,64 @@ public class UnmarkTaskCommandParser implements AnimalParser<UnmarkTaskCommand> 
 
         String[] indexLists = trimmedArgs.split("\\s+", 2);
 
+        // checks if animal index is a number
+        if (!indexLists[0].matches("\\d+")) {
+            throw new ParseException("Animal " + MESSAGE_INVALID_DOUBLE_INDEX);
+        }
 
-        Index animalIndex = Index.fromOneBased(Integer.parseInt(indexLists[0]));
-        Index[] taskIndex = stream(indexLists[1].split("\\s+"))
+        // checks if animal index is an integer
+        if (Double.parseDouble(indexLists[0]) % 1 != 0) {
+            throw new ParseException("Animal " + MESSAGE_INVALID_DOUBLE_INDEX);
+        }
+
+        int animalIntIndex = Integer.parseInt(indexLists[0]);
+
+        // checks if animal index provided is negative
+        if (animalIntIndex <= 0) {
+            throw new ParseException("Animal " + MESSAGE_NEGATIVE_INDEX);
+        }
+
+
+        // checks to ensure task index provided are valid
+
+        // checks if task indexes provided are numbers
+        if (!indexLists[1].matches("\\d+(\\s+\\d+)*")) {
+            throw new ParseException("Task " + MESSAGE_INVALID_STRING_INDEX);
+        }
+
+        double[] checkTaskIndexes = stream(indexLists[1].split("\\s+"))
+                .map(Double::parseDouble)
+                .mapToDouble(Double::doubleValue)
+                .toArray();
+
+        // check if indexes provided are negative
+        if (stream(checkTaskIndexes).anyMatch(index -> index <= 0)) {
+            throw new ParseException("Task " + MESSAGE_NEGATIVE_INDEX);
+        }
+
+        // check if indexes provided are integers
+        if (stream(checkTaskIndexes).anyMatch(index -> index % 1 != 0)) {
+            throw new ParseException("Task " + MESSAGE_INVALID_DOUBLE_INDEX);
+        }
+
+
+        Index animalIndex = Index.fromOneBased(animalIntIndex);
+        Index[] taskIndexes = stream(indexLists[1].split("\\s+"))
                 .map(Integer::parseInt)
                 .map(Index::fromOneBased)
                 .toArray(Index[]::new);
 
-        return new UnmarkTaskCommand(animalIndex, taskIndex);
+
+        return new UnmarkTaskCommand(animalIndex, taskIndexes);
     }
 
     private static String getAnimalHelpMessage() {
         return AnimalMessages.getFormattedHelpMessage(
-                MESSAGE_MISSING_ANIMAL_INDEX, MarkTaskCommand.MESSAGE_USAGE);
+                MESSAGE_MISSING_ANIMAL_INDEX, UnmarkTaskCommand.MESSAGE_USAGE);
     }
 
     private static String getTaskHelpMessage() {
         return AnimalMessages.getFormattedHelpMessage(
-                MESSAGE_MISSING_TASK_INDEX, MarkTaskCommand.MESSAGE_USAGE);
+                MESSAGE_MISSING_TASK_INDEX, UnmarkTaskCommand.MESSAGE_USAGE);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkTaskCommandParser.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.parser;
 
 import static java.util.Arrays.stream;
-import static seedu.address.logic.AnimalMessages.*;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_DOUBLE_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_INVALID_STRING_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_ANIMAL_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_MISSING_TASK_INDEX;
+import static seedu.address.logic.AnimalMessages.MESSAGE_NEGATIVE_INDEX;
 
 import java.util.logging.Logger;
 

--- a/src/main/java/seedu/address/model/animal/Animal.java
+++ b/src/main/java/seedu/address/model/animal/Animal.java
@@ -153,6 +153,10 @@ public class Animal {
         taskList.resetTasks();
     }
 
+    public int getNumberOfTasks() {
+        return taskList.getNumberOfTasks();
+    }
+
     /**
      * Returns the string representation of this Animal.
      *

--- a/src/main/java/seedu/address/model/animal/TaskList.java
+++ b/src/main/java/seedu/address/model/animal/TaskList.java
@@ -100,6 +100,15 @@ public class TaskList {
         return this;
     }
 
+    /**
+     * Returns the number of tasks in the taskList.
+     *
+     * @return The number of tasks in the taskList.
+     */
+    public int getNumberOfTasks() {
+        return taskList.size();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
Reset: update `message_usage`

Mark and unmark: add checks to make sure
- index is a number, not a string
- index is not negative
- index is an integer
- number of task indexes is less than the number of tasks the animal has
- the largest task index indicated does not exceed the number of tasks the animal has
Tasks are only updated after these checks