### PR TITLE
Fix/help command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -26,8 +26,7 @@ public class DeleteTaskCommand extends AnimalCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes a specific task from an animal's task list.\n"
-            + "Parameters: ANIMALINDEX TASKINDEX (must both be positive integers)\n"
-            + EXAMPLE_USAGE;
+            + "Parameters: ANIMAL_INDEX TASK_INDEX (must both be positive integers)";
 
     public static final String MESSAGE_SUCCESS = "Task deleted for %s: %s";
 
@@ -45,6 +44,15 @@ public class DeleteTaskCommand extends AnimalCommand {
 
         this.targetAnimalIndex = targetAnimalIndex;
         this.targetTaskIndex = targetTaskIndex;
+    }
+
+    /**
+     * Returns the help message of this command.
+     *
+     * @return a string containing the help message of this command.
+     */
+    public static String getHelp() {
+        return String.format(AnimalMessages.MESSAGE_HELP_FORMAT, MESSAGE_USAGE, EXAMPLE_USAGE);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/HelpAnimalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpAnimalCommand.java
@@ -1,8 +1,12 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.AnimalModel;
 import seedu.address.model.CommandEnum;
 
@@ -24,7 +28,14 @@ public class HelpAnimalCommand extends AnimalCommand {
     public static final String MESSAGE_UNRECOGNIZED_COMMAND_FORMAT = "Command: %s not recognized!";
     private final String targetCommandWord;
 
+    /**
+     * Constructs an instance of {@code HelpAnimalCommand}, with a specified
+     * {@code targetCommandWord}.
+     *
+     * @param targetCommandWord the command to search for. Must not be null.
+     */
     public HelpAnimalCommand(String targetCommandWord) {
+        requireNonNull(targetCommandWord);
         this.targetCommandWord = targetCommandWord;
     }
 
@@ -46,5 +57,24 @@ public class HelpAnimalCommand extends AnimalCommand {
         }
 
         return new CommandResult(helpMessage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetCommandWord);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof HelpAnimalCommand // instanceof handles nulls
+            && targetCommandWord.equals(((HelpAnimalCommand) other).targetCommandWord));
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .add("toSearch", targetCommandWord)
+            .toString();
     }
 }

--- a/src/main/java/seedu/address/model/CommandEnum.java
+++ b/src/main/java/seedu/address/model/CommandEnum.java
@@ -4,6 +4,7 @@ package seedu.address.model;
 import seedu.address.logic.commands.AddAnimalCommand;
 import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.DeleteAnimalCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditAnimalCommand;
 import seedu.address.logic.commands.HelpAnimalCommand;
 import seedu.address.logic.commands.ListAnimalCommand;
@@ -19,6 +20,7 @@ public enum CommandEnum {
     ADD_ANIMAL_COMMAND(AddAnimalCommand.COMMAND_WORD, AddAnimalCommand.getHelp()),
     ADD_TASK_COMMAND(AddTaskCommand.COMMAND_WORD, AddTaskCommand.getHelp()),
     DELETE_ANIMAL_COMMAND(DeleteAnimalCommand.COMMAND_WORD, DeleteAnimalCommand.getHelp()),
+    DELETE_TASK_COMMAND(DeleteTaskCommand.COMMAND_WORD, DeleteTaskCommand.getHelp()),
     EDIT_ANIMAL_COMMAND(EditAnimalCommand.COMMAND_WORD, EditAnimalCommand.getHelp()),
     LIST_ANIMAL_COMMAND(ListAnimalCommand.COMMAND_WORD, ListAnimalCommand.getHelp()),
     MARK_TASK_COMMAND(MarkTaskCommand.COMMAND_WORD, MarkTaskCommand.getHelp()),

--- a/src/test/java/seedu/address/logic/commands/AddAnimalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAnimalCommandTest.java
@@ -75,7 +75,7 @@ public class AddAnimalCommandTest {
         // null -> returns false
         assertNotEquals(null, addTofuCommand);
 
-        // different person -> returns false
+        // different animal -> returns false
         assertNotEquals(addTofuCommand, addMuffinCommand);
     }
 

--- a/src/test/java/seedu/address/logic/commands/HelpAnimalCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpAnimalCommandTest.java
@@ -1,0 +1,87 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import seedu.address.model.AnimalModel;
+
+public class HelpAnimalCommandTest {
+    public static final String VALID_ADD_LOWERCASE = "add";
+    public static final String VALID_ADD_UPPERCASE = "ADD";
+    public static final String VALID_ADD_PARTIAL = "ad";
+    public static final String INVALID_COMMAND = "someCommandThatDoesNotExist";
+
+    @Mock
+    private AnimalModel mockedModel;
+
+    @Test
+    public void constructor_withNullInput_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new HelpAnimalCommand(null));
+    }
+
+    @Test
+    public void execute_withEmptyString_returnsProgramUsage() {
+        CommandResult expectedResult = new CommandResult(HelpAnimalCommand.MESSAGE_USAGE, true, false);
+        CommandResult actual = new HelpAnimalCommand("").execute(mockedModel);
+        assertEquals(expectedResult, actual);
+    }
+
+    @Test
+    public void execute_withValidAdd_returnsAddAnimalAndAddTaskCommandHelp() {
+        String expected = String.format("%s\n\n%s", AddAnimalCommand.getHelp(), AddTaskCommand.getHelp());
+        String actualLowerCase = new HelpAnimalCommand(VALID_ADD_LOWERCASE).execute(mockedModel).getFeedbackToUser();
+        String actualUpperCase = new HelpAnimalCommand(VALID_ADD_UPPERCASE).execute(mockedModel).getFeedbackToUser();
+
+        assertEquals(expected, actualLowerCase);
+        assertEquals(expected, actualUpperCase);
+    }
+
+    @Test
+    public void execute_withValidPartialAdd_returnsAddAnimalAndAddTaskCommandHelp() {
+        String expected = String.format("%s\n\n%s", AddAnimalCommand.getHelp(), AddTaskCommand.getHelp());
+        String actual = new HelpAnimalCommand(VALID_ADD_PARTIAL).execute(mockedModel).getFeedbackToUser();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void execute_withInvalidTargetWord_returnsUnrecognizedInputMessage() {
+        String expected = String.format(HelpAnimalCommand.MESSAGE_UNRECOGNIZED_COMMAND_FORMAT, INVALID_COMMAND);
+        String actual = new HelpAnimalCommand(INVALID_COMMAND).execute(mockedModel).getFeedbackToUser();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void equals() {
+        HelpAnimalCommand helpAddCommand = new HelpAnimalCommand(VALID_ADD_LOWERCASE);
+        HelpAnimalCommand helpAddCommandPartial = new HelpAnimalCommand(VALID_ADD_PARTIAL);
+
+        // same object -> returns true
+        assertEquals(helpAddCommand, helpAddCommand);
+
+        // same values -> returns true
+        HelpAnimalCommand helpAddCopy = new HelpAnimalCommand(VALID_ADD_LOWERCASE);
+        assertEquals(helpAddCommand, helpAddCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, helpAddCommand);
+
+        // null -> returns false
+        assertNotEquals(null, helpAddCommand);
+
+        // different target word -> returns false
+        assertNotEquals(helpAddCopy, helpAddCommandPartial);
+    }
+
+    @Test
+    public void toStringMethod() {
+        HelpAnimalCommand helpAnimalCommand = new HelpAnimalCommand(VALID_ADD_LOWERCASE);
+        String expected = HelpAnimalCommand.class.getCanonicalName() + "{toSearch=" + VALID_ADD_LOWERCASE + "}";
+        assertEquals(expected, helpAnimalCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/HelpAnimalCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/HelpAnimalCommandParserTest.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.parser.AnimalCommandParserTestUtil.assertParseFailure;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.HelpAnimalCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.CommandEnum;
+
+public class HelpAnimalCommandParserTest {
+    public static final String VALID_COMMAND_WORD = "add";
+    public static final String INVALID_NUMBERS = "123";
+    public static final String INVALID_WHITESPACE = "add command";
+    public static final String INVALID_ALPHANUMERIC = "add 123";
+    public static final String INVALID_SYMBOLS = "@@";
+    public static final String VALID_LEADING_WHITESPACE = "   " + VALID_COMMAND_WORD;
+    public static final String VALID_TRAILING_WHITESPACE = VALID_COMMAND_WORD + "  ";
+    public static final List<String> ALL_VALID_COMMANDS = Arrays.stream(CommandEnum.values())
+        .map(CommandEnum::getCommandWord)
+        .collect(Collectors.toList());
+
+    private final HelpAnimalCommandParser helpCommandParser = new HelpAnimalCommandParser();
+
+    @Test
+    public void parseHelp_withInvalidInputs_throwsParseException() {
+        assertParseFailure(helpCommandParser, INVALID_NUMBERS, HelpAnimalCommand.MESSAGE_USAGE);
+        assertParseFailure(helpCommandParser, INVALID_WHITESPACE, HelpAnimalCommand.MESSAGE_USAGE);
+        assertParseFailure(helpCommandParser, INVALID_ALPHANUMERIC, HelpAnimalCommand.MESSAGE_USAGE);
+        assertParseFailure(helpCommandParser, INVALID_SYMBOLS, HelpAnimalCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parseHelp_withValidInputs_returnsHelpCommand() {
+        try {
+            assertEquals(HelpAnimalCommand.class, helpCommandParser.parse(VALID_COMMAND_WORD).getClass());
+            assertEquals(HelpAnimalCommand.class, helpCommandParser.parse(VALID_LEADING_WHITESPACE).getClass());
+            assertEquals(HelpAnimalCommand.class, helpCommandParser.parse(VALID_TRAILING_WHITESPACE).getClass());
+
+            for (String validCommands: ALL_VALID_COMMANDS) {
+                assertEquals(HelpAnimalCommand.class, helpCommandParser.parse(validCommands).getClass());
+            }
+        } catch (ParseException ignored) {
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
Fix Help Command not working with DeleteTask Command, e.g. `help deletetask`.

Also add tests for Help command and Help command parser.

Resolves #192, #134